### PR TITLE
[TESTING] net/mlx5: fix indirect age action handling

### DIFF
--- a/doc/guides/nics/mlx5.rst
+++ b/doc/guides/nics/mlx5.rst
@@ -769,6 +769,8 @@ Limitations
       in different flows may cause a wrong age state for the age actions.
     - Creating/destroying flow rules with indirect age action when it is active
       (timeout != 0) may cause a wrong age state for the indirect age action.
+    - If strict queueing is enabled (``RTE_FLOW_PORT_FLAG_STRICT_QUEUE`` flag)
+      indirect age flow actions can be created only through asynchronous flow API.
 
     - The driver reuses counters for aging action, so for optimization
       the values in ``rte_flow_port_attr`` structure should describe:

--- a/drivers/net/mlx5/mlx5_flow_hw.c
+++ b/drivers/net/mlx5/mlx5_flow_hw.c
@@ -3176,6 +3176,7 @@ flow_hw_shared_action_construct(struct rte_eth_dev *dev, uint32_t queue,
 	uint32_t type = act_idx >> MLX5_INDIRECT_ACTION_TYPE_OFFSET;
 	uint32_t idx = act_idx &
 		       ((1u << MLX5_INDIRECT_ACTION_TYPE_OFFSET) - 1);
+	uint32_t *cnt_queue;
 	cnt_id_t age_cnt;
 
 	memset(&act_data, 0, sizeof(act_data));
@@ -3226,9 +3227,8 @@ flow_hw_shared_action_construct(struct rte_eth_dev *dev, uint32_t queue,
 		if (param == NULL)
 			return -1;
 		if (action_flags & MLX5_FLOW_ACTION_COUNT) {
-			if (mlx5_hws_cnt_pool_get(priv->hws_cpool,
-						  &param->queue_id, &age_cnt,
-						  idx) < 0)
+			cnt_queue = mlx5_hws_cnt_get_queue(priv, &queue);
+			if (mlx5_hws_cnt_pool_get(priv->hws_cpool, cnt_queue, &age_cnt, idx) < 0)
 				return -1;
 			flow->flags |= MLX5_FLOW_HW_FLOW_FLAG_CNT_ID;
 			flow->cnt_id = age_cnt;
@@ -13124,6 +13124,15 @@ flow_hw_action_create(struct rte_eth_dev *dev,
 		       const struct rte_flow_action *action,
 		       struct rte_flow_error *err)
 {
+	struct mlx5_priv *priv = dev->data->dev_private;
+
+	if (action->type == RTE_FLOW_ACTION_TYPE_AGE && priv->hws_strict_queue) {
+		rte_flow_error_set(err, EINVAL, RTE_FLOW_ERROR_TYPE_STATE, NULL,
+				   "Cannot create age action synchronously "
+				   "when strict queueing is enabled");
+		return NULL;
+	}
+
 	return flow_hw_action_handle_create(dev, MLX5_HW_INV_QUEUE,
 					    NULL, conf, action, NULL, err);
 }


### PR DESCRIPTION
Indirect AGE flow actions can be created either through synchronous or asynchronous flow API.
mlx5 PMD stores the queue used to create that action to support strict queueing. When action is created through synchronous API invalid queue index is stored instead.

Whenever a flow rule is created with indirect AGE and direct COUNT flow actions, PMD allocates a HW counter for ageing that flow rule during rule creation.
During allocation of the counter a queue index is needed to select a proper counter pool cache.

In case when indirect AGE action created through synchronous API was used in that case, the associated queue index was used to select pool cache. Since queue index was invalid, PMD crashed.

Counter can be allocated using the index of currently used queue and it does not have to match the queue used to create AGE action.

This patch fixes the crash by using the index of currently used queue.

This patch also adds missing validation for synchronous AGE flow action creation - this method cannot be used when strict queueing is enabled, since a correct queue is required for ageing. PMD documentation is updated accordingly.

Fixes: 04a4de756e14 ("net/mlx5: support flow age action with HWS")
Cc: michaelba@nvidia.com
Cc: stable@dpdk.org